### PR TITLE
Add interactive visualization to surface code subsection

### DIFF
--- a/docs/notebooks/ch4-repcodes-to-surfcodes/syndrome-extraction-cycle-surface-code.ipynb
+++ b/docs/notebooks/ch4-repcodes-to-surfcodes/syndrome-extraction-cycle-surface-code.ipynb
@@ -518,6 +518,28 @@
     "syndrome_extractor = SyndromeExtraction(distance = 3)\n",
     "syndrome_extractor.print_syndrome_circuits()"
    ]
+  }, 
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## <font color='blue'>Interactive exercise: Visualize syndrome extraction over time</font>\n",
+    "\n",
+    "Now that we've implemented syndrome extraction, we're at a point to begin thinking about our QEC code at the chip level. Below is an example of our current progress implemented on the topology of [Google's Willow processor](https://quantumai.google/static/site-assets/downloads/willow-spec-sheet.pdf). As an interactive exercise, you can use the editor to:\n",
+    "\n",
+    "1. Move the slider across the moments to observe how the gates look at different timesteps\n",
+    "2. Understand the code and figure out how we translated our existing code to fit on the processor\n",
+    "3. *Stretch goal.* Implement the rotated surface code in the last part on the Willow processor, and see how the gates are modified.\n",
+    "4. *Stretch goal.* Implement a smaller distance code to see if you can fit multiple logical qubits on the processor.\n",
+    "\n",
+    "<iframe\n",
+    "  src=\"https://qernelzoo.com/lattice?noescape=1&starter_code=r1\"\n",
+    "  style=\"width:100%;height:700px;border:0;border-radius:12px\"\n",
+    "  loading=\"lazy\"\n",
+    "  allow=\"clipboard-read; clipboard-write; fullscreen\"\n",
+    "  sandbox=\"allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads\"\n",
+    "></iframe>"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
While going through this textbook to brush up my QEC, I found myself wanting to play around with these code structures on chip, but also found myself getting too lazy to set up an environment. I ended up writing a custom IDE/sandbox environment that is portable, can run in the browser, and shows up well in Jupyter Notebook environments. This PR introduces the ability for others to use it in the in the textbook. 

Users can now visualize codes in the textbook on Google's Willow/Sycamore chip topologies. A video of the functionality is attached below. The backend servers for this are hosted free thanks to a grant from the [Unitary Foundation](https://unitary.foundation/grants/).

https://github.com/user-attachments/assets/c34283d9-7a3b-4da3-b01c-22b0424ad4ca



