### PR TITLE
Remove 'remove-input' tag from notebook

### DIFF
--- a/docs/notebooks/ch1-intuition/classical-intuition.ipynb
+++ b/docs/notebooks/ch1-intuition/classical-intuition.ipynb
@@ -37,9 +37,7 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": [
-     "remove-input"
-    ]
+    "tags": []
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
Show the import cell to replicate the code without errors.