### PR TITLE
Update link for Dan Browne's lectures

### DIFF
--- a/docs/notebooks/about-this-textbook.ipynb
+++ b/docs/notebooks/about-this-textbook.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "There are several places where you can obtain a deep understanding of QEC concepts. However, fully detailed implementations of quantum circuits in QEC are not widely available. For this reason, this hands-on textbook is best used as a supplement to another textbook that provides grounding in the principles of QEC. Some recommended resources:\n",
     "\n",
-    "- Dan Browne's [Lectures on Topological Codes and Quantum Computation](https://sites.google.com/site/danbrowneucl/teaching/lectures-on-topological-codes-and-quantum-computation)\n",
+    "- Dan Browne's [Lectures on Topological Codes and Quantum Computation](https://sites.google.com/site/danbrowneucl/lectures-on-topological-codes-and-quantum-computation?authuser=0)\n",
     "- John Preskill's [Ph219 lecture notes](https://www.preskill.caltech.edu/ph219/) (particularly Chapter 7)\n",
     "- Daniel Gottesman's [PhD dissertation on Stabilizer Codes and Quantum Error Correction](https://arxiv.org/pdf/quant-ph/9705052)\n",
     "\n",


### PR DESCRIPTION
Updated the link for Dan Browne's lectures on topological codes and quantum computation