### PR TITLE
Update error frequency statistics in notebook

### DIFF
--- a/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
+++ b/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
@@ -1050,7 +1050,7 @@
    "id": "e2ec2375-7b38-4b44-9e1f-694f371455cb",
    "metadata": {},
    "source": [
-    "As you can see, there is only one way to have weight-0 errors (no errors on all qubits), and that occurs with a frequency of about 200,000 times out of a total of 100 million samples (0.2%), 7 different ways to have weight-1 errors (one error on each qubit at distance 7), each of which occurs about 50,000 times (0.05%), and so on. \n",
+    "As you can see, there is only one way to have weight-0 errors (no errors on all qubits), and that occurs with a frequency of about 200,000 times out of a total of 1 million samples (20%$ \\approx 0.8^7$), 7 different ways to have weight-1 errors (one error on each qubit at distance 7), each of which occurs about 50,000 times (5%$ \\approx 0.2 \\cdot 0.8^6), and so on. \n",
     "\n",
     "So far, we have been sampling all error patterns (in the above example, we would have sampled all 10 million error patterns). But as you can see above, there is a significant amount of redundancy in doing so, and grouping should provide significant speedup if we can predetermine the weights of these groupings.\n",
     "\n",

--- a/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
+++ b/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
@@ -924,7 +924,7 @@
    "source": [
     "So far, we have sampled all $10\\times10^9$ shots from the syndrome table. By reducing the number of circuit executions to just the number of circuits needed to prepare the syndrome table, and sampling from that table repeatedly without running circuits, we have achieved the speedups that we have seen so far.\n",
     "\n",
-    "To motivate additional speedups, it's instructive to look at the generated error patterns that we are looking up in the syndrome table. Below, we demonstrate the error patterns for distance 7, with physical error probability 0.2, and 100 million shots."
+    "To motivate additional speedups, it's instructive to look at the generated error patterns that we are looking up in the syndrome table. Below, we demonstrate the error patterns for distance 7, with physical error probability $p_{err}=0.2$, and 1 million shots."
    ]
   },
   {
@@ -945,7 +945,7 @@
    },
    "outputs": [],
    "source": [
-    "def show_error_pattern_distribution(n_qubits, error_probability, n_shots=10_000_000):\n",
+    "def show_error_pattern_distribution(n_qubits, error_probability, n_shots=1_000_000):\n",
     "    \n",
     "    # Generate error patterns\n",
     "    error_patterns = np.random.random((n_shots, n_qubits)) < error_probability\n",
@@ -954,9 +954,9 @@
     "    error_weights = np.sum(error_patterns, axis=1)\n",
     "    weight_counts = Counter(error_weights)\n",
     "\n",
-    "    # Convert patterns to tuples for counting, 1M at a time\n",
+    "    # Convert patterns to tuples for counting\n",
     "    pattern_list = []\n",
-    "    for pattern in error_patterns[:min(1_000_000, n_shots)]:\n",
+    "    for pattern in error_patterns[:n_shots]:\n",
     "        error_locations = tuple(np.where(pattern)[0])\n",
     "        pattern_list.append(error_locations)\n",
     "    pattern_counts = Counter(pattern_list)\n",
@@ -1042,7 +1042,7 @@
     }
    ],
    "source": [
-    "show_error_pattern_distribution(n_qubits = 7, error_probability = 0.2, n_shots = 100_000_000)"
+    "show_error_pattern_distribution(n_qubits = 7, error_probability = 0.2, n_shots = 1_000_000)"
    ]
   },
   {
@@ -1050,9 +1050,9 @@
    "id": "e2ec2375-7b38-4b44-9e1f-694f371455cb",
    "metadata": {},
    "source": [
-    "As you can see, there is only one way to have weight-0 errors (no errors on all qubits), and that occurs with a frequency of about 200,000 times out of a total of 1 million samples (20%$ \\approx 0.8^7$), 7 different ways to have weight-1 errors (one error on each qubit at distance 7), each of which occurs about 50,000 times (5%$ \\approx 0.2 \\cdot 0.8^6), and so on. \n",
+    "As you can see, there is only one way to have weight-0 errors (no errors on all qubits), and that occurs with a frequency of about 200,000 times out of a total of 1 million samples (20%$ \\approx p_{err}^0 \\cdot (1 - p_{err})^7 = 1 \\cdot 0.8^7$), 7 different ways to have weight-1 errors (one error on each qubit at distance 7), each of which occurs about 50,000 times (5%$ \\approx p_{err}^1 \\cdot (1 - p_{err})^6 = 0.2 \\cdot 0.8^6$), and so on. \n",
     "\n",
-    "So far, we have been sampling all error patterns (in the above example, we would have sampled all 10 million error patterns). But as you can see above, there is a significant amount of redundancy in doing so, and grouping should provide significant speedup if we can predetermine the weights of these groupings.\n",
+    "So far, we have been sampling all error patterns (in the above example, we would have sampled all 1 million error patterns). But as you can see above, there is a significant amount of redundancy in doing so, and grouping should provide significant speedup if we can predetermine the weights of these groupings.\n",
     "\n",
     "Can you take advantage of this observation to further reduce the simulation time? If so, as you can see above, there is an additional ~10000x to be gained. :)"
    ]

--- a/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
+++ b/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
@@ -956,7 +956,7 @@
     "\n",
     "    # Convert patterns to tuples for counting\n",
     "    pattern_list = []\n",
-    "    for pattern in error_patterns[:n_shots]:\n",
+    "    for pattern in error_patterns:\n",
     "        error_locations = tuple(np.where(pattern)[0])\n",
     "        pattern_list.append(error_locations)\n",
     "    pattern_counts = Counter(pattern_list)\n",

--- a/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
+++ b/docs/notebooks/ch2-classical-to-quantum-repcodes/running-faster-circuit-simulations.ipynb
@@ -1050,7 +1050,7 @@
    "id": "e2ec2375-7b38-4b44-9e1f-694f371455cb",
    "metadata": {},
    "source": [
-    "As you can see, there is only one way to have weight-0 errors (no errors on all qubits), and that occurs with a frequency of about 200,000 times out of a total of 1 million samples (20%$ \\approx p_{err}^0 \\cdot (1 - p_{err})^7 = 1 \\cdot 0.8^7$), 7 different ways to have weight-1 errors (one error on each qubit at distance 7), each of which occurs about 50,000 times (5%$ \\approx p_{err}^1 \\cdot (1 - p_{err})^6 = 0.2 \\cdot 0.8^6$), and so on. \n",
+    "As you can see, there is only one way to have weight-0 errors (no errors on all qubits), and that occurs with a frequency of about 200,000 times out of a total of 1 million samples (20% $ \\approx p_{err}^0 \\cdot (1 - p_{err})^7 = 1 \\cdot 0.8^7$), 7 different ways to have weight-1 errors (one error on each qubit at distance 7), each of which occurs about 50,000 times (5% $ \\approx p_{err}^1 \\cdot (1 - p_{err})^6 = 0.2 \\cdot 0.8^6$), and so on. \n",
     "\n",
     "So far, we have been sampling all error patterns (in the above example, we would have sampled all 1 million error patterns). But as you can see above, there is a significant amount of redundancy in doing so, and grouping should provide significant speedup if we can predetermine the weights of these groupings.\n",
     "\n",


### PR DESCRIPTION
From the code in the last hidden cell source one can see that only 1 million shots are used (" for pattern in error_patterns[:min(1_000_000, n_shots)]:"), thus the current probabilities are 100 times smaller than the correct ones. The corrected probabilities match with the exact ones from multinomial distribution. Finally selecting just 1 million samples seems to suggest an implementation of the batching previously explained, however the two techniques are independent, thus I would also set n_shots=1 million for the whole last paragraph and eliminate the min function above.